### PR TITLE
Move `swap_labels` button

### DIFF
--- a/napari/_qt/layer_controls/qt_labels_controls.py
+++ b/napari/_qt/layer_controls/qt_labels_controls.py
@@ -231,12 +231,12 @@ class QtLabelsControls(QtLayerControls):
 
         button_row = QHBoxLayout()
         button_row.addStretch(1)
-        button_row.addWidget(self.colormapUpdate)
         button_row.addWidget(self.erase_button)
         button_row.addWidget(self.paint_button)
         button_row.addWidget(self.fill_button)
         button_row.addWidget(self.pick_button)
         button_row.addWidget(self.panzoom_button)
+        button_row.addWidget(self.colormapUpdate)
         button_row.setSpacing(4)
         button_row.setContentsMargins(0, 0, 0, 5)
 


### PR DESCRIPTION
# Description
Hi @mstabrin here's a PR to make Labels buttons also consistent in order 1–5, as I mentioned here:
https://github.com/napari/napari/pull/5021#issuecomment-1239303572

Makes it look like this:
<img width="254" alt="image" src="https://user-images.githubusercontent.com/76622105/188876233-6deff0e2-2ca9-410a-b93b-3e43ea9666a2.png">

